### PR TITLE
feat(landing): make terminal interactive with command pill row

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,26 +11,10 @@ const links = [
 ];
 
 const projects = [
-  {
-    label: "wp-rocket",
-    description: "gutenberg blocks development",
-    href: "https://wp-rocket.me",
-  },
-  {
-    label: "rank-math",
-    description: "support page redesign",
-    href: "https://rankmath.com/support/",
-  },
-  {
-    label: "axonaut",
-    description: "blog redesign & development",
-    href: "https://axonaut.com/blog/",
-  },
-  {
-    label: "lemlist",
-    description: "academy development on wordpress",
-    href: "https://academy.lemlist.com/",
-  },
+  { label: "wp-rocket", description: "gutenberg blocks development", href: "https://wp-rocket.me" },
+  { label: "rank-math", description: "support page redesign", href: "https://rankmath.com/support/" },
+  { label: "axonaut", description: "blog redesign & development", href: "https://axonaut.com/blog/" },
+  { label: "lemlist", description: "academy development on wordpress", href: "https://academy.lemlist.com/" },
 ];
 
 const name = "valentin grenier";
@@ -49,30 +33,84 @@ const status = [
   "// status: open to freelance.",
   "// available for wordpress, gutenberg, headless, and front-end work.",
 ];
+
+const commands = [
+  { name: "help",     description: "list available commands" },
+  { name: "whoami",   description: "display user info" },
+  { name: "about",    description: "show bio" },
+  { name: "status",   description: "show availability" },
+  { name: "projects", description: "list selected projects" },
+  { name: "socials",  description: "list social links" },
+  { name: "privacy",  description: "show privacy note" },
+  { name: "clear",    description: "clear the screen" },
+];
 ---
 
 <Terminal
   title="Valentin Grenier — Web developer"
   description="Valentin Grenier — web developer based in Toulouse, France."
 >
-  <section class="block">
-    <Prompt cmd="whoami" />
+  <div class="boot" data-boot aria-hidden="true"></div>
+
+  <div class="reveal" data-reveal>
+    <div class="history" data-history aria-live="polite" aria-atomic="false"></div>
+
+    <div class="shell" data-shell>
+      <Prompt><span class="cursor" aria-hidden="true">█</span></Prompt>
+      <nav
+        class="pills"
+        data-pills
+        role="toolbar"
+        aria-label="Available commands"
+      >
+        {
+          commands.map((cmd, i) => (
+            <button
+              class="pill"
+              data-pill={cmd.name}
+              tabindex={i === 0 ? 0 : -1}
+              type="button"
+            >
+              <span class="pill__bracket" aria-hidden="true">[</span>
+              <span class="pill__name">{cmd.name}</span>
+              <span class="pill__bracket" aria-hidden="true">]</span>
+            </button>
+          ))
+        }
+      </nav>
+    </div>
+  </div>
+
+  <template data-cmd="help">
+    <p class="output output--dim">
+      // click a pill below, or use ← → + enter.
+    </p>
+    <ul class="help-list" role="list">
+      {
+        commands.map((cmd) => (
+          <li>
+            <span class="help-cmd">{cmd.name}</span>
+            <span class="output--dim">— {cmd.description}</span>
+          </li>
+        ))
+      }
+    </ul>
+  </template>
+
+  <template data-cmd="whoami">
     <h1 class="output output--name">{name}</h1>
     {taglines.map((line) => <p class="output output--dim">{line}</p>)}
-  </section>
+  </template>
 
-  <section class="block">
-    <Prompt cmd="cat about.txt" />
+  <template data-cmd="about">
     {about.map((line) => <p class="output output--dim">{line}</p>)}
-  </section>
+  </template>
 
-  <section class="block">
-    <Prompt cmd="cat status.txt" />
+  <template data-cmd="status">
     {status.map((line) => <p class="output output--dim">{line}</p>)}
-  </section>
+  </template>
 
-  <section class="block">
-    <Prompt cmd="ls projects/" />
+  <template data-cmd="projects">
     <nav class="links" aria-label="Projects">
       <ul role="list">
         {
@@ -90,9 +128,7 @@ const status = [
                 <span class="label">
                   {project.label} — {project.description}
                 </span>
-                <span class="arrow" aria-hidden="true">
-                  ↗
-                </span>
+                <span class="arrow" aria-hidden="true">↗</span>
                 <span class="sr-only">(opens in a new tab)</span>
               </a>
             </li>
@@ -100,10 +136,9 @@ const status = [
         }
       </ul>
     </nav>
-  </section>
+  </template>
 
-  <section class="block">
-    <Prompt cmd="ls socials/" />
+  <template data-cmd="socials">
     <nav class="links" aria-label="Social links">
       <ul role="list">
         {
@@ -119,9 +154,7 @@ const status = [
                   [{String(i + 1).padStart(2, "0")}]
                 </span>
                 <span class="label">{link.label}</span>
-                <span class="arrow" aria-hidden="true">
-                  ↗
-                </span>
+                <span class="arrow" aria-hidden="true">↗</span>
                 <span class="sr-only">(opens in a new tab)</span>
               </a>
             </li>
@@ -129,17 +162,171 @@ const status = [
         }
       </ul>
     </nav>
-  </section>
+  </template>
 
-  <section class="block">
-    <Prompt cmd="cat privacy.note" />
+  <template data-cmd="privacy">
     <p class="output output--dim">
       // privacy-friendly analytics — no cookies, no personal data collected.
     </p>
     <p class="output output--dim">
       // full notice: <a href="/privacy" class="inline-link">/privacy</a>
     </p>
-  </section>
+  </template>
 
-  <Prompt><span class="cursor" aria-hidden="true">█</span></Prompt>
+  <script is:inline>
+    (() => {
+      const root = document.documentElement;
+      const boot = document.querySelector("[data-boot]");
+      const reveal = document.querySelector("[data-reveal]");
+      const history = document.querySelector("[data-history]");
+      const shell = document.querySelector("[data-shell]");
+      const pills = document.querySelector("[data-pills]");
+      if (!boot || !reveal || !history || !shell || !pills) return;
+
+      const PROMPT_HTML =
+        '<span class="ps-user">valentin</span>' +
+        '<span class="ps-sep">@</span>' +
+        '<span class="ps-host">portfolio</span>' +
+        '<span class="ps-sep">:</span>' +
+        '<span class="ps-path">~</span>' +
+        '<span class="ps-dollar">$</span>';
+
+      const escapeHtml = (s) =>
+        s.replace(/[&<>"']/g, (c) => ({
+          "&": "&amp;",
+          "<": "&lt;",
+          ">": "&gt;",
+          '"': "&quot;",
+          "'": "&#39;",
+        }[c]));
+
+      function runCommand(cmd) {
+        if (cmd === "clear") {
+          history.replaceChildren();
+          return;
+        }
+
+        const tpl = document.querySelector(
+          'template[data-cmd="' + cmd + '"]'
+        );
+        const block = document.createElement("section");
+        block.className = "block";
+
+        const promptLine = document.createElement("p");
+        promptLine.className = "prompt-line";
+        promptLine.innerHTML =
+          PROMPT_HTML +
+          ' <span class="ps-cmd">' +
+          escapeHtml(cmd) +
+          "</span>";
+        block.appendChild(promptLine);
+
+        if (tpl) {
+          block.appendChild(tpl.content.cloneNode(true));
+        }
+
+        history.appendChild(block);
+        shell.scrollIntoView({ block: "end", behavior: "smooth" });
+      }
+
+      // -------- pill row keyboard nav --------
+
+      const pillItems = () => Array.from(pills.querySelectorAll(".pill"));
+
+      function focusPill(idx) {
+        const list = pillItems();
+        if (!list.length) return;
+        const i = ((idx % list.length) + list.length) % list.length;
+        list.forEach((b) => b.setAttribute("tabindex", "-1"));
+        list[i].setAttribute("tabindex", "0");
+        list[i].focus();
+      }
+
+      pills.addEventListener("click", (e) => {
+        const pill = e.target.closest(".pill");
+        if (!pill) return;
+        const cmd = pill.dataset.pill;
+        if (!cmd) return;
+        pillItems().forEach((b) => b.setAttribute("tabindex", "-1"));
+        pill.setAttribute("tabindex", "0");
+        runCommand(cmd);
+      });
+
+      pills.addEventListener("keydown", (e) => {
+        const list = pillItems();
+        const idx = list.indexOf(document.activeElement);
+        if (idx < 0) return;
+        switch (e.key) {
+          case "ArrowRight":
+          case "ArrowDown":
+            e.preventDefault();
+            focusPill(idx + 1);
+            break;
+          case "ArrowLeft":
+          case "ArrowUp":
+            e.preventDefault();
+            focusPill(idx - 1);
+            break;
+          case "Home":
+            e.preventDefault();
+            focusPill(0);
+            break;
+          case "End":
+            e.preventDefault();
+            focusPill(list.length - 1);
+            break;
+        }
+      });
+
+      // -------- boot animation → reveal --------
+
+      function startInteractive() {
+        runCommand("help");
+        reveal.classList.add("is-revealed");
+      }
+
+      const animate = root.classList.contains("js-reveal");
+
+      if (!animate) {
+        startInteractive();
+        return;
+      }
+
+      const date = new Date().toUTCString().replace("GMT", "UTC");
+      const localPromptHtml =
+        '<span class="ps-user">guest</span>' +
+        '<span class="ps-sep">@</span>' +
+        '<span class="ps-host">web</span>' +
+        '<span class="ps-sep">:</span>' +
+        '<span class="ps-path">~</span>' +
+        '<span class="ps-dollar">$</span> ' +
+        '<span class="ps-cmd">ssh valentin@portfolio</span>';
+
+      const lines = [
+        { delay: 200, html: localPromptHtml },
+        { delay: 450, text: "Connecting to portfolio.valentin.dev...", dim: true },
+        { delay: 600, text: "Authenticating session...", dim: true },
+        { delay: 500, text: "Connection established.", cls: "boot-line--ok" },
+        { delay: 350, text: "Last login: " + date + ".", dim: true },
+        { delay: 350, text: "Welcome to portfolio.valentin.dev." },
+      ];
+
+      let t = 0;
+      lines.forEach((line) => {
+        t += line.delay;
+        setTimeout(() => {
+          const p = document.createElement("p");
+          p.className =
+            "output boot-line" +
+            (line.dim ? " output--dim" : "") +
+            (line.cls ? " " + line.cls : "");
+          if (line.html) p.innerHTML = line.html;
+          else p.textContent = line.text;
+          boot.appendChild(p);
+        }, t);
+      });
+
+      setTimeout(startInteractive, t + 500);
+    })();
+  </script>
 </Terminal>

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -343,6 +343,135 @@ body {
   }
 }
 
+// ----- boot reveal -----
+
+// Boot section: empty in the static markup, populated line-by-line by JS.
+// Hidden when empty so reduced-motion / no-JS sessions show no gap.
+.boot {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+
+  &:empty {
+    display: none;
+  }
+}
+
+.boot-line {
+  animation: bootLineIn 220ms var(--ease) both;
+}
+
+.boot-line--ok {
+  color: #27c93f;
+}
+
+// Reveal wrapper: re-creates the body's flex+gap so the terminal layout is
+// preserved whether or not the reveal animation runs.
+.reveal {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+// Only hide the reveal when JS confirmed it can animate it back in — keeps
+// the no-JS / reduced-motion fallback fully accessible.
+html.js-reveal .reveal {
+  opacity: 0;
+  pointer-events: none;
+}
+
+html.js-reveal .reveal.is-revealed {
+  opacity: 1;
+  pointer-events: auto;
+  animation: fadeUp 700ms var(--ease) both;
+}
+
+// ----- interactive shell -----
+
+.history {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+
+  &:empty {
+    display: none;
+  }
+}
+
+.shell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 0.4rem;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.pill {
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  padding: 0.1rem 0.3rem;
+  margin: 0;
+  font: inherit;
+  font-size: inherit;
+  color: var(--fg);
+  cursor: pointer;
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0;
+  transition:
+    color var(--duration) var(--ease),
+    background-color var(--duration) var(--ease);
+
+  &:hover,
+  &:focus-visible {
+    color: var(--accent);
+    background-color: var(--accent-soft);
+
+    .pill__bracket {
+      color: var(--accent);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+}
+
+.pill__bracket {
+  color: var(--fg-decor);
+  transition: color var(--duration) var(--ease);
+}
+
+// ----- help command output -----
+
+.help-list {
+  list-style: none;
+  margin: 0.1rem 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 0.6rem;
+  row-gap: 0;
+
+  li {
+    display: contents;
+  }
+}
+
+.help-cmd {
+  color: var(--accent);
+}
+
 // ----- animations -----
 
 @keyframes blink {
@@ -366,12 +495,25 @@ body {
   }
 }
 
+@keyframes bootLineIn {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 // ----- accessibility -----
 
 @media (prefers-reduced-motion: reduce) {
   .terminal,
   .foot,
-  .cursor {
+  .cursor,
+  .boot-line,
+  .reveal {
     animation: none;
   }
 
@@ -379,7 +521,9 @@ body {
   .num,
   .arrow,
   .label::after,
-  .foot a {
+  .foot a,
+  .pill,
+  .pill__bracket {
     transition: none;
   }
 


### PR DESCRIPTION
## Summary
- After the SSH boot, the terminal becomes interactive: an auto-run `help` lands in history, with an active prompt and a pill row for every command.
- Click a pill or arrow-navigate (←/→/↑/↓/Home/End) + Enter/Space to run a command. Output accumulates above the prompt like a real shell session.
- `clear` wipes history. Everything else appends.
- Each command's output is server-rendered into a `<template>` (driven by the same `links` / `projects` / `about` / `status` data as before — no duplication), cloned into history at runtime.

## Commands
`help`, `whoami`, `about`, `status`, `projects`, `socials`, `privacy`, `clear`

## Accessibility
- Pill row uses roving tabindex (`role="toolbar"`, `aria-label="Available commands"`).
- History is `aria-live="polite"` so screen readers announce new output.
- Boot section is `aria-hidden`.
- `prefers-reduced-motion` skips the boot animation and reveals the interactive shell immediately.

## Test plan
- [ ] Boot sequence still plays; reveal fades in with `help` already shown.
- [ ] Click each pill — output appends; `clear` wipes.
- [ ] Tab into pill row, navigate with ←/→, activate with Enter/Space.
- [ ] Run the same command twice — verify accumulation.
- [ ] `prefers-reduced-motion` set: no boot, content visible immediately, `help` still shown.
- [ ] Mobile: pill row wraps; help-list grid stays readable.
- [ ] Project / social links inside cloned templates open in new tab.

https://claude.ai/code/session_01SSKVpzZq3cEZEYmX9hh939

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSKVpzZq3cEZEYmX9hh939)_